### PR TITLE
Add -t flag to target the space containing the route

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Bound to:
 $ cf lookup-route -t <my.example.com>
 Bound to:
 <org>/<space>/<app>
+Changed target to: <org>/<space>
 
 $ cf lookup-route <unknown.example.com>
 Error retrieving apps: Route not found.

--- a/README.md
+++ b/README.md
@@ -14,9 +14,15 @@ This is a Cloud Foundry CLI plugin to find the application a given hostname/doma
 ## Usage
 
 ```
-$ cf lookup-route <my.domain.com>
+$ cf lookup-route <my.example.com>
 Bound to:
 <org>/<space>/<app>
-$ cf lookup-route <unknown.domain.com>
+
+# use -t to target the org/space containing the route
+$ cf lookup-route -t <my.example.com>
+Bound to:
+<org>/<space>/<app>
+
+$ cf lookup-route <unknown.example.com>
 Error retrieving apps: Route not found.
 ```

--- a/main.go
+++ b/main.go
@@ -64,6 +64,17 @@ func (c *BasicPlugin) Run(cliConnection plugin.CliConnection, args []string) {
 		if err != nil {
 			log.Fatal("Error targeting app: ", err)
 		}
+
+		space, err := apps[0].GetSpace(cliConnection)
+		if err != nil {
+			log.Fatal("Error retrieving space: ", err)
+		}
+		org, err := space.GetOrg(cliConnection)
+		if err != nil {
+			log.Fatal("Error retrieving org: ", err)
+		}
+
+		log.Println("Changed target to:", org.Entity.Name + "/" + space.Entity.Name)
 	}
 
 }

--- a/models.go
+++ b/models.go
@@ -59,6 +59,20 @@ func (a App) GetSpace(cliConnection plugin.CliConnection) (space Space, err erro
 	return
 }
 
+func (a App) Target(cliConnection plugin.CliConnection) ([]string, error) {
+	space, err := a.GetSpace(cliConnection)
+	if err != nil {
+		return nil, err
+	}
+
+	org, err := space.GetOrg(cliConnection)
+	if err != nil {
+		return nil, err
+	}
+
+	return cliConnection.CliCommandWithoutTerminalOutput("target", "-o", org.Entity.Name, "-s", space.Entity.Name)
+}
+
 type AppsResponse struct {
 	NextUrl   string `json:"next_url"`
 	Resources []App  `json:"resources"`


### PR DESCRIPTION
I've gotten tired of copying and pasting this output into the `cf target` command. 😁 
